### PR TITLE
Changes to secondPK function

### DIFF
--- a/MatModel.py
+++ b/MatModel.py
@@ -259,9 +259,17 @@ class InvariantHyperelastic:
                 for i,m in enumerate(self.M):
                     S += 2.*dPsidI1[i]*I #contribution from I1 for each different value of I4
         if dPsidI2 is not None:
-            S += 2.*dPsidI2*(self.I1*I-np.dot(F.transpose(),F)) #contribution from I2
+            if type(dPsidI2) != list:
+                S += 2.*dPsidI2*(self.I1*I-np.dot(F.transpose(),F)) #contribution from I2
+            else:
+                for i,m in enumerate(self.M):
+                    S += 2.*dPsidI2[i]*(self.I1*I-np.dot(F.transpose(),F)) #contribution from I2 for each different value of I4
         if dPsidJ is not None:
-            S += dPsidJ*self.J*np.linalg.inv(np.dot(F.transpose(),F)) #contribution from J
+            if type(dPsidJ) != list:
+                S += dPsidJ*self.J*np.linalg.inv(np.dot(F.transpose(),F)) #contribution from J
+            else:
+                for i,m in enumerate(self.M):
+                    S += dPsidJ[i]*self.J*np.linalg.inv(np.dot(F.transpose(),F)) #contribution from J for each different value of I4
         if dPsidI4 is not None:
             if type(dPsidI4) != list:
                 for i,m in enumerate(self.M):


### PR DESCRIPTION
No rush to review and merge these changes before you are back. Maybe good to have a discussion in person about it before merging.

I'm pretty sure there is a more elegant way to achieve this than what I have implemented just now. The reason for making these changes are in the case that:
- dPsidI1(I_{4,i})
- dPsidI2(I_{4,i})
- dPsidJ(I_{4,i})
- dPsidI4(I1, I2, J)

As the function was, these scenarios result in dPsidI4 being a floating point value which is not iterable. Likewise, dPsidI1, 2, and J are all lists which need to be summed for each I4, in each fibre direction.

This code achieves this based on whether the returned value of the derivative is a list or not.