### PR TITLE
Added helper functions for assigning fiber directions

### DIFF
--- a/pymecht/SampleExperiment.py
+++ b/pymecht/SampleExperiment.py
@@ -920,7 +920,7 @@ class LayeredTube(LayeredSamples):
             s._output = self._output
         return XI,Stress
 
-def specify_single_fiber(sample,angle=0, radians=True, verbose=True):
+def specify_single_fiber(sample,angle=0, degrees=True, verbose=True):
     '''
     Assign single fiber direction to all materials in a sample
 
@@ -939,28 +939,28 @@ def specify_single_fiber(sample,angle=0, radians=True, verbose=True):
         for UniformAxisymmetricTubeInflationExtension
             with respect to the theta-axis and in the theta-z plane
 
-    radians: bool
-        If True, the angle is asssumed to be in radians. If False, it is assumed to be in degrees; default True
+    degrees: bool
+        If True, the angle is asssumed to be in degrees. If False, it is assumed to be in radians; default True
 
     verbose: bool
         If True, the function prints the angle after assigning, default True
 
     '''
-    if not radians:
-        angle = np.deg2rad(angle)
+    if degrees:
+        angle_rad = np.deg2rad(angle)
     models = sample._mat_model.models
     if isinstance(sample,UniformAxisymmetricTubeInflationExtension):
-        vec = np.array([0,np.cos(angle), np.sin(angle)])
+        vec = np.array([0,np.cos(angle_rad), np.sin(angle_rad)])
     elif isinstance(sample,PlanarBiaxialExtension) or isinstance(sample,UniaxialExtension):
-        vec = np.array([np.cos(angle), np.sin(angle),0])
+        vec = np.array([np.cos(angle_rad), np.sin(angle_rad),0])
     else:
         raise ValueError("The helper function is only implemented for UniaxialExtension, PlanarBiaxialExtension, and UniformAxisymmetricTubeInflationExtension")
     for m in models:
         m.fiber_dirs = vec
     if verbose:
-        print("Fiber directions set to ",angle," radians")
+        print("Fiber directions set to ",angle," degrees (", angle_rad, " radians)")
 
-def specify_two_fibers(sample,angle, radians = True, verbose=True):
+def specify_two_fibers(sample,angle, degrees = True, verbose=True):
     '''
     Assign two symmetric fiber directions to all materials in a sample
 
@@ -979,23 +979,23 @@ def specify_two_fibers(sample,angle, radians = True, verbose=True):
         for UniformAxisymmetricTubeInflationExtension
             with respect to the theta-axis and in the theta-z plane
 
-    radians: bool
-        If True, the angle is asssumed to be in radians. If False, it is assumed to be in degrees; default True
+    degrees: bool
+        If True, the angle is asssumed to be in degrees. If False, it is assumed to be in radians; default True
 
     verbose: bool
         If True, the function prints the angle after assigning, default True
 
     '''
-    if not radians:
-        angle = np.deg2rad(angle)
+    if degrees:
+        angle_rad = np.deg2rad(angle)
     models = sample._mat_model.models
     if isinstance(sample,UniformAxisymmetricTubeInflationExtension):
-        vec = [np.array([0,np.cos(angle), np.sin(angle)]), np.array([0,np.cos(-angle), np.sin(-angle)])]
+        vec = [np.array([0,np.cos(angle_rad), np.sin(angle_rad)]), np.array([0,np.cos(-angle_rad), np.sin(-angle_rad)])]
     elif isinstance(sample,PlanarBiaxialExtension) or isinstance(sample,UniaxialExtension):
-        vec = [np.array([np.cos(angle), np.sin(angle),0]), np.array([np.cos(-angle), np.sin(-angle),0])]
+        vec = [np.array([np.cos(angle_rad), np.sin(angle_rad),0]), np.array([np.cos(-angle_rad), np.sin(-angle_rad),0])]
     else:
         raise ValueError("The helper function is only implemented for UniaxialExtension, PlanarBiaxialExtension, and UniformAxisymmetricTubeInflationExtension")
     for m in models:
         m.fiber_dirs = vec
     if verbose:
-        print("Fiber directions set to +-",angle," radians")
+        print("Fiber directions set to ",angle," degrees (", angle_rad, " radians)")

--- a/pymecht/SampleExperiment.py
+++ b/pymecht/SampleExperiment.py
@@ -920,3 +920,82 @@ class LayeredTube(LayeredSamples):
             s._output = self._output
         return XI,Stress
 
+def specify_single_fiber(sample,angle=0, radians=True, verbose=True):
+    '''
+    Assign single fiber direction to all materials in a sample
+
+    Parameters
+    ----------
+
+    sample: SampleExperiment
+        The sample to which fiber directions need to be assigned
+
+    angle: float
+        The angle of the fiber direction, default 0 
+
+        for UniaxialExtension or PlanarBiaxialExtension
+            with respect to the x-axis and in the xy plane
+
+        for UniformAxisymmetricTubeInflationExtension
+            with respect to the theta-axis and in the theta-z plane
+
+    radians: bool
+        If True, the angle is asssumed to be in radians. If False, it is assumed to be in degrees; default True
+
+    verbose: bool
+        If True, the function prints the angle after assigning, default True
+
+    '''
+    if not radians:
+        angle = np.deg2rad(angle)
+    models = sample._mat_model.models
+    if isinstance(sample,UniformAxisymmetricTubeInflationExtension):
+        vec = np.array([0,np.cos(angle), np.sin(angle)])
+    elif isinstance(sample,PlanarBiaxialExtension) or isinstance(sample,UniaxialExtension):
+        vec = np.array([np.cos(angle), np.sin(angle),0])
+    else:
+        raise ValueError("The helper function is only implemented for UniaxialExtension, PlanarBiaxialExtension, and UniformAxisymmetricTubeInflationExtension")
+    for m in models:
+        m.fiber_dirs = vec
+    if verbose:
+        print("Fiber directions set to ",angle," radians")
+
+def specify_two_fibers(sample,angle, radians = True, verbose=True):
+    '''
+    Assign two symmetric fiber directions to all materials in a sample
+
+    Parameters
+    ----------
+
+    sample: SampleExperiment
+        The sample to which fiber directions need to be assigned
+
+    angle: float
+        The angle of the fiber directions (assigned as :math:`\pm` angle) 
+
+        for UniaxialExtension or PlanarBiaxialExtension
+            with respect to the x-axis and in the xy plane
+        
+        for UniformAxisymmetricTubeInflationExtension
+            with respect to the theta-axis and in the theta-z plane
+
+    radians: bool
+        If True, the angle is asssumed to be in radians. If False, it is assumed to be in degrees; default True
+
+    verbose: bool
+        If True, the function prints the angle after assigning, default True
+
+    '''
+    if not radians:
+        angle = np.deg2rad(angle)
+    models = sample._mat_model.models
+    if isinstance(sample,UniformAxisymmetricTubeInflationExtension):
+        vec = [np.array([0,np.cos(angle), np.sin(angle)]), np.array([0,np.cos(-angle), np.sin(-angle)])]
+    elif isinstance(sample,PlanarBiaxialExtension) or isinstance(sample,UniaxialExtension):
+        vec = [np.array([np.cos(angle), np.sin(angle),0]), np.array([np.cos(-angle), np.sin(-angle),0])]
+    else:
+        raise ValueError("The helper function is only implemented for UniaxialExtension, PlanarBiaxialExtension, and UniformAxisymmetricTubeInflationExtension")
+    for m in models:
+        m.fiber_dirs = vec
+    if verbose:
+        print("Fiber directions set to +-",angle," radians")


### PR DESCRIPTION
Two helper functions: one for assigning one fiber direction at an angle, and the other for assigning two fiber directions at angles +-angles (i.e. symmetric). The axis with respect to which the angle is measured and plane of fibers are chosen based on the sample type. For uniax and biax, fibers are in xy plane and at angle with respect to x axis. For tube, fibers are in the theta-z plane with respect to the theta axis.