### PR TITLE
Added auto-version using setuptools_scm

### DIFF
--- a/pymecht/__init__.py
+++ b/pymecht/__init__.py
@@ -23,3 +23,12 @@ from .RandomParameters import *
 from .SampleExperiment import *
 from .ParamFitter import *
 from .MCMC import *
+
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("pymecht")
+except PackageNotFoundError:
+    # package is not installed
+    pass
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,11 @@
 [build-system]
-requires = ["setuptools"]  # the build tool to use
+requires = ["setuptools","setuptools_scm>=8"]  # the build tool to use
 build-backend = "setuptools.build_meta"  # the function to use to build the package
 
 [project]
 name = "pymecht"
-version = "0.9"
+#version = "0.9"
+dynamic = ["version"]
 description = "This is PYthon-based repository is for MECHanics of Tissue mechanics. The focus is on flexibility of adding new constitutive models and varying their parameters."
 readme = "README.md"
 authors = [{ name = "Ankush Aggarwal", email = "ankush.aggarwal@glasgow.ac.uk" }, { name = "Ross Williams", email = "r.williams.2@research.gla.ac.uk" }]
@@ -14,6 +15,10 @@ requires-python = ">=3.8"
 [project.optional-dependencies]
 dev = ["pytest >= 7.2.0"]
 
+[tool.setuptools_scm]
+version_file = "pymecht/_version.py"
+version_scheme = "no-guess-dev"
+local_scheme = "no-local-version"
 #[project.scripts]
 #greet = "greetings.command:process"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "pymecht"
 dynamic = ["version"]
 description = "This is PYthon-based repository is for MECHanics of Tissue mechanics. The focus is on flexibility of adding new constitutive models and varying their parameters."
 readme = "README.md"
-authors = [{ name = "Ankush Aggarwal", email = "ankush.aggarwal@glasgow.ac.uk" }, { name = "Ross Williams", email = "r.williams.2@research.gla.ac.uk" }]
+authors = [{ name = "Ankush Aggarwal", email = "ankush.aggarwal@glasgow.ac.uk" }, { name = "Ross Williams", email = "ross.williams@glasgow.ac.uk" }]
 dependencies = ["matplotlib >= 3.4.1", "numpy >= 1.22.2", "pyDOE >= 0.3.8", "scipy >= 1.8.0", "torch >= 1.10.1", "sympy >= 1.10.1", "tqdm >= 4.61.0", "pandas >= 1.2.4"]
 requires-python = ">=3.8"
 


### PR DESCRIPTION
The version of library is automated by using library [setuptools_scm](https://setuptools-scm.readthedocs.io/en/latest/). The version will be of the form [tag].post[N].dev[M] where tag is assigned with github. Whenever we assign a new tag, that version will be uploaded to pypi as well.