### PR TITLE
Updated @v as per github webpage

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -24,9 +24,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
Updated @v in ci-test.yml as per the github page at https://github.com/marketplace/actions/setup-python

This was needed as otherwise the tests for MacOS were failing with the error that "python version was not found"