### PR TITLE
Documentation fix

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # Defining the exact version will make sure things don't break
-sphinx==5.3.0
+sphinx==6.1.3
 sphinx_rtd_theme==1.1.1
 readthedocs-sphinx-search==0.3.2
 sphinx-autodoc-typehints==1.23.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,6 @@ sphinx==6.1.3
 sphinx_rtd_theme==1.2.0
 readthedocs-sphinx-search==0.3.2
 sphinx-autodoc-typehints==1.23.0
-sphinx-rtd-theme==1.2.1
 sphinxcontrib.applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
 sphinxcontrib-htmlhelp==2.0.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 # Defining the exact version will make sure things don't break
 sphinx==6.1.3
-sphinx_rtd_theme==1.1.1
+sphinx_rtd_theme==1.2.0
 readthedocs-sphinx-search==0.3.2
 sphinx-autodoc-typehints==1.23.0
-sphinx-rtd-theme==1.1.1
-sphinxcontrib.applehelp==1.0.3
+sphinx-rtd-theme==1.2.1
+sphinxcontrib.applehelp==1.0.4
 sphinxcontrib-devhelp==1.0.2
-sphinxcontrib-htmlhelp==2.0.0
+sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -19,3 +19,5 @@ pyDOE==0.3.8
 tqdm>=4.61.0
 sympy>=1.10.1
 matplotlib>=3.4.1
+setuptools==65.6.3
+setuptools_scm>=8


### PR DESCRIPTION
I realized that the documentation was not building correctly. Some module reference pages were empty (e.g. https://pymecht.readthedocs.io/en/latest/sampleexperiment.html) After a lot of digging, I found the issue was setuptools updated (70.+) version. Therefore, fixing it in the requirements to lower version. See other reports of this at https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/15863#issuecomment-2124913627 

Some other updates in the versions are not central, but they work fine