### PR TITLE
Warnings update

### DIFF
--- a/Tests/test_examples.py
+++ b/Tests/test_examples.py
@@ -73,7 +73,7 @@ def test_layered_samples():
     material = MatModel('goh','nh')
     mm = material.models
     mm[0].fiber_dirs = [np.array([cos(0.),sin(0.),0])]
-    sample = LayeredUniaxial(UniaxialExtension(material),UniaxialExtension(material))
+    sample = LayeredUniaxial(UniaxialExtension(material, disp_measure='length', force_measure='force'),UniaxialExtension(material,disp_measure='length', force_measure='force'))
     assert isinstance(sample, LayeredSamples)
     assert len(sample._samples) == 2
     assert sample._samples[0]._mat_model == material
@@ -81,7 +81,7 @@ def test_layered_samples():
     assert sample.disp_controlled(sample._samples[0]._x0, sample.parameters) == pytest.approx(0.0)
     assert sample.force_controlled(np.zeros_like(sample._samples[0]._x0), sample.parameters) == pytest.approx(sample._samples[0]._x0)
 
-    sample = LayeredPlanarBiaxial(PlanarBiaxialExtension(material,force_measure='force'),PlanarBiaxialExtension(material,force_measure='force'))
+    sample = LayeredPlanarBiaxial(PlanarBiaxialExtension(material,disp_measure='length',force_measure='force'),PlanarBiaxialExtension(material,disp_measure='length',force_measure='force'))
     assert isinstance(sample, LayeredSamples)
     assert len(sample._samples) == 2
     assert sample._samples[0]._mat_model == material

--- a/pymecht/SampleExperiment.py
+++ b/pymecht/SampleExperiment.py
@@ -904,8 +904,10 @@ class LayeredUniaxial(LayeredSamples):
         super().__init__(*samplesList)
         if not all([isinstance(s,UniaxialExtension) for s in self._samples]):
             raise ValueError("The class only accepts objects of type UniaxialExtension")
+        if self._inp != 'length':
+            raise ValueError("The input of all layers in LayeredUniaxial should be length to remove ambiguity about the reference length")
         if self._output != 'force':
-            warnings.warn("The output of the LayeredUniaxial should be force, as stresses are not additive. The results may be spurious")
+            raise ValueError("The output of the LayeredUniaxial should be force, as stresses are not additive. The results may be spurious")
 
 class LayeredPlanarBiaxial(LayeredSamples):
     '''
@@ -929,8 +931,10 @@ class LayeredPlanarBiaxial(LayeredSamples):
         super().__init__(*samplesList)
         if not all([isinstance(s,PlanarBiaxialExtension) for s in self._samples]):
             raise ValueError("The class only accepts objects of type PlanarBiaxialExtension")
+        if self._inp != 'length':
+            raise ValueError("The input of all layers in LayeredPlanarBiaxial should be length to remove ambiguity about the reference length")
         if self._output != 'force':
-            warnings.warn("The output of the LayeredPlanarBiaxial should be force, as stresses are not additive. The results may be spurious")
+            raise ValueError("The output of the LayeredPlanarBiaxial should be force, as stresses are not additive. The results may be spurious")
 
 class LayeredTube(LayeredSamples):
     '''


### PR DESCRIPTION
For `LayeredUniaxial` and `LayeredPlanarBiaxial` there was a warning in place that the `force_measure` should be force rather than stress of any kind. That has been changed to an error to enforce the requirement. Also, another check regarding `disp_measure` has been added, since it should be length, otherwise the results are incorrect (a different reference length for each layer is used, which defeats the purpose of layering them).