### PR TITLE
Changes to installation instructions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,7 +18,7 @@ jobs:
       # will run even if one or more fail. 
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -18,7 +18,7 @@ jobs:
       # will run even if one or more fail. 
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
     
     runs-on: ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,14 +9,15 @@ To install as a devloper, it is recommended to fork from the repo and clone this
 
 To create an environment in Anaconda, execute:
 ```sh
-conda create -n pymecht
+conda create -n pymecht python=3.9 ipykernel
 ```
+Python3.9 is suggested, although any of the currently-supported versions of Python will also work.
 
 To activate this virtual environment, execute:
 ```sh
 conda activate pymecht
 ```
-This is an option, but recommended step. There are other options for create and managing environments (such as venv or virtualenv)
+This is an optional, but recommended, step. There are other options for creating and managing environments (such as venv or virtualenv)
 
 ### *Step 2: Install via pip*
 To install as a devloper, it is recommended to fork from the repo and clone this fork locally.
@@ -32,7 +33,7 @@ where `<repo-address>` can be replaced by either the https or ssh addresses of t
 ### *Step 2.3 Install developer version of pyMechT*
 To install a developer version of pyMechT, navigate to the locally cloned repo and execute:
 ```sh
-python setup.py develop
+pip install -e .
 ```
 An editable version of pyMechT is now installed. All local changes to the cloned source code files will be reflected when pyMechT is imported.
 

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Required dependencies are:
 
 To create an environment in Anaconda, execute:
 ```sh
-conda create -n pymecht python=3.X
+conda create -n pymecht python=3.9 ipykernel
 ```
-where X is any of the currently-supported versions of Python from 3.8 until 3.12.
+Python3.9 is suggested, although any of the currently-supported versions of Python will also work.
 
 To activate this virtual environment, execute:
 ```sh
 conda activate pymecht
 ```
-This is an option, but recommended step. There are other options for create and managing environments (such as venv or virtualenv)
+This is an optional, but recommended, step. There are other options for creating and managing environments (such as venv or virtualenv)
 
 ### *Step 2: Install via pip*
 
@@ -79,7 +79,7 @@ where `<repo-address>` can be replaced by either the https or ssh addresses of t
 ### *Step 2.3 Install developer version of pyMechT*
 To install a developer version of pyMechT, navigate to the locally cloned repo and execute:
 ```sh
-python setup.py develop
+pip install -e .
 ```
 An editable version of pyMechT is now installed. All local changes to the cloned source code files will be reflected when pyMechT is imported.
 

--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Required dependencies are:
 
 To create an environment in Anaconda, execute:
 ```sh
-conda create -n pymecht
+conda create -n pymecht python=3.X
 ```
+where X is any of the currently-supported versions of Python from 3.8 until 3.12.
 
 To activate this virtual environment, execute:
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![PyPI - Version](https://img.shields.io/pypi/v/pymecht) ![Build Status](https://github.com/ankushaggarwal/pymecht/actions/workflows/ci-tests.yml/badge.svg) [![Documentation Status](https://readthedocs.org/projects/pymecht/badge/?version=latest)](https://pymecht.readthedocs.io/en/latest/?badge=latest) ![Python versions](https://img.shields.io/badge/python-3.8%2B-blue.svg) ![GitHub](https://img.shields.io/github/license/ankushaggarwal/pymecht)
+![PyPI - Version](https://img.shields.io/pypi/v/pymecht) ![Build Status](https://github.com/ankushaggarwal/pymecht/actions/workflows/ci-tests.yml/badge.svg) [![Documentation Status](https://readthedocs.org/projects/pymecht/badge/?version=latest)](https://pymecht.readthedocs.io/en/latest/?badge=latest) ![Python versions](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Fankushaggarwal%2Fpymecht%2Fmaster%2Fpyproject.toml
+) ![GitHub](https://img.shields.io/github/license/ankushaggarwal/pymecht)
 
 # pyMechT
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "This is PYthon-based repository is for MECHanics of Tissue mechan
 readme = "README.md"
 authors = [{ name = "Ankush Aggarwal", email = "ankush.aggarwal@glasgow.ac.uk" }, { name = "Ross Williams", email = "ross.williams@glasgow.ac.uk" }]
 dependencies = ["matplotlib >= 3.4.1", "numpy >= 1.22.2", "pyDOE >= 0.3.8", "scipy >= 1.8.0", "torch >= 1.13.1", "sympy >= 1.10.1", "tqdm >= 4.61.0", "pandas >= 1.2.4"]
-requires-python = ">=3.8"
+requires-python = ">=3.8,<3.13"
 
 [project.optional-dependencies]
 dev = ["pytest >= 7.2.0"]


### PR DESCRIPTION
Now I have further investigated the issue, PyTorch is not supported on Python3.13. This was the issue that the reviewers were encountering, I reckon.

All tests pass for >=3.8 and <3.13. As such, I have changed the supported versions to also be in this range. I have updated the shield to be automatically pulled from the pyproject.toml file and there is now installation instructions with the Python version included. I am less inclined to state a specific version as I have no reason for the user to use 3.8 over 3.12, for example.